### PR TITLE
MT Marathon 2022 starting point

### DIFF
--- a/stopes/modules/bitext/mining/mine_bitext_indexes_utils.py
+++ b/stopes/modules/bitext/mining/mine_bitext_indexes_utils.py
@@ -81,6 +81,10 @@ def mine(
     compute_margin_scores(neighbors_y2x, avg_y2x, avg_x2y)
 
     logger.info("Starting fastmax retrieval with threshold {:f}".format(threshold))
+
+    # the retrieval of the matching sentences is done in `fastmax_retrieval`. If you 
+    # wanted to use a different mining approach, you could just change this call.
+    
     fastmax_neighbors = fastmax_retrieval(
         neighbors_x2y, neighbors_y2x, k_extract, threshold
     )
@@ -98,6 +102,13 @@ def mine(
         src_idx[pos] = source_index
         tgt_idx[pos] = target_index
         pos += 1
+
+    # Alignments represent the aligned pairs of sentences from the data as retrieved
+    # by the above `fastmax_retrieval`.
+    # - src_idx represents the sentence id from the original src_text_files. There might be multiple shards of src
+    # the index is sequential from the first line of the first file in the list to the last line of the last file in the list
+    # see mine_bitext_sentences_utils._load_data for an example of how to retrieve text lines.
+    # - tgt_idx represents the aligned sentence in the destination file
 
     post_margin_alignments = Alignments(
         scores=dists,

--- a/stopes/pipelines/bitext/conf/mine_indexes/base.yaml
+++ b/stopes/pipelines/bitext/conf/mine_indexes/base.yaml
@@ -7,8 +7,10 @@ config:
     #set later in pipeline
     src2tgt_dist_files: ???
     src2tgt_index_files: ???
+    src_text_files: ???
     tgt2src_dist_files: ???
     tgt2src_index_files: ???
+    tgt_text_files: ???
 
     output_dir: ???
     knn_dist: 16
@@ -20,3 +22,4 @@ config:
     num_probe: 128
     gpu_type: fp16-shard
     mine_threshold: 1.06
+    filter_step: null

--- a/stopes/pipelines/bitext/global_mining_pipeline.py
+++ b/stopes/pipelines/bitext/global_mining_pipeline.py
@@ -270,8 +270,10 @@ class GlobalMiningPipeline:
             index_type=src_index_type,
             src2tgt_dist_files=src2tgt_dist_files,
             src2tgt_index_files=src2tgt_index_files,
+            src_text_files=src_text_shards,
             tgt2src_dist_files=tgt2src_dist_files,
             tgt2src_index_files=tgt2src_index_files,
+            tgt_text_files=tgt_text_shards,
         )
         mined_indexes = await self.launcher.schedule(mine_indexes_module)
 


### PR DESCRIPTION
## Why ?

This is example code of how to change the mining pipeline to add some extra filtering in the mining phase as a starting point for the Prague's MT Marathon 2022.

Check the changes to `mine_bitext_intexes_utils.py` where you can see where the core mining is done from the list of neighbours and were posthoc filtering could be inserted.

## How ?

1. try the quickstart: https://facebookresearch.github.io/stopes/docs/quickstart this will show how to get data and run the mining pipeline end to end
2. check this PR to see how the code is changed to pass down a config for the filter + the list of original text shards to the mining step. You could use the `filter_config` to pass down the path to a trained classifier or other parameters to the filtering if you wanted.
3. replace `noop_filter` with something smarter to filter out the mined candidates.
4. stopes will cache most steps. If you change the utils, bump the version in `stopes/modules/bitext/mining/mine_bitext_indexes.py` to make sure to recompute what you are changing. Then you can run the whole pipeline with the same command each time.