### PR TITLE
etox: apply toxicity detection to the clean sentence

### DIFF
--- a/toxicity-alti-hb/ETOX/etox.py
+++ b/toxicity-alti-hb/ETOX/etox.py
@@ -224,7 +224,8 @@ def etox_single(
 
     # clean up the strings before toxicity check:
     # lowercases everying, removing punctuation to spaces,
-    df_Eval = txt_format(df_Eval, col_name_in="string_raw", col_name="string_clean")
+    clean_colname = "string_clean"
+    df_Eval = txt_format(df_Eval, col_name_in="string_raw", col_name=clean_colname)
     df_Eval.loc[:, ["token_level"]] = token_level
 
     # Load the toxicity word list:
@@ -237,23 +238,23 @@ def etox_single(
 
     # uses a different tokenizer depending on input parameter
     if token_level == "space":
-        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval["string_raw"].apply(
+        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval[clean_colname].apply(
             token_checker, toxic_word_list=toxicity_list
         )
 
     elif token_level == "character":
-        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval["string_raw"].apply(
+        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval[clean_colname].apply(
             substring_checker, toxic_word_list=toxicity_list
         )
 
     elif token_level == "SPM":
         spm_toxicity_list = [sp.encode_as_pieces(x.lower()) for x in toxicity_list]
-        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval["string_raw"].apply(
+        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval[clean_colname].apply(
             SPM_token_checker, spm_tokenized_toxic_word_list=spm_toxicity_list
         )
 
     elif token_level == "custom":
-        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval["string_raw"].apply(
+        df_Eval.loc[:, ["matched_toxicity_list"]] = df_Eval[clean_colname].apply(
             tokenizer, toxic_word_list=toxicity_list
         )
 


### PR DESCRIPTION
## Why ?

It is a fix of the bug in the ETOX tool that crept in when the tool was ported into Stopes: it used the raw version of the input sentence to detect toxicity, instead of the clean sentence. As a result, some toxic words were not detected. 

## How ?

Use the `string_clean` column instead of `string_raw`.

## Test plan

The following code tests that a toxic word can be detected even if it is attached to a punctuation mark, which requires a clean version of the text.

```
import etox
import pandas as pd

data_in = pd.DataFrame({'string_raw': ['Who is the kid of this dog?']})
data_out = pd.DataFrame({'string_raw': ['¿Quién es esto hijo de puta?']})
data_in.index.name = 'Dataset_ID'
data_out.index.name = 'Dataset_ID'

comparison = etox.etox_paired(
    data_in,
    data_out,
    'eng_Latn_twl.txt',
    'spa_Latn_twl.txt',
    A_prefix='en_', B_prefix='es_',
)
assert comparison.found_toxicity_list[0] == ['puta']
```
