### PR TITLE
Explore folders feature (backend side)

### DIFF
--- a/stopes/ui/seamlisten/backend/app/fileviewer.py
+++ b/stopes/ui/seamlisten/backend/app/fileviewer.py
@@ -9,6 +9,7 @@ import itertools
 import typing as tp
 import zipfile
 from pathlib import Path
+import os
 
 import torchaudio
 from fastapi import APIRouter
@@ -86,6 +87,7 @@ def open_segment_tsv(file: str, start_idx: int, end_idx: int) -> tp.List[LineRes
     with stutils.open(file) as f:
         for line in itertools.islice(f, start_idx, end_idx):
             results.append(auto_parse_line(line.strip()))
+            print("result", results)
     return results
 
 
@@ -131,7 +133,14 @@ def get_annotations(
 @router.post("/general/")
 async def general_query(query: DefaultQuery) -> Response:
     query_path = query.gz_path.strip()
-    print(query_path.split(" "))
+    # Convert the path to an absolute path
+    query_path = str(Path(os.path.expanduser(query_path)).resolve())
+    # Check if the path is a directory
+    print(query_path)
+    if os.path.isdir(query_path):
+        result_data = gather_folder_contents(query_path)
+        return result_data
+
     if query_path.endswith(".tsv.gz") or query_path.endswith(".zip"):
         return get_annotations(
             AnnotationQuery(
@@ -150,7 +159,6 @@ async def general_query(query: DefaultQuery) -> Response:
             AudioQuery(sampling="ms", path=path, start=int(start), end=int(end))
         )
         return result
-
     else:
         raise HTTPException(
             status_code=500,
@@ -161,3 +169,24 @@ async def general_query(query: DefaultQuery) -> Response:
         a line with audio file, start and end timestamps
         """,
         )
+
+
+import os
+
+
+def gather_folder_contents(folder_path, max_depth=3):
+    folder_contents = []
+    for root, dirs, files in os.walk(folder_path, topdown=True):
+        depth = root[len(folder_path) + len(os.path.sep) :].count(os.path.sep)
+        if depth <= max_depth:
+            folder_data = {
+                "folder": root,
+                "subfolders": dirs,
+                "audio_files": [
+                    file for file in files if file.endswith((".wav", ".ms"))
+                ],
+            }
+            folder_contents.append(folder_data)
+            if depth == max_depth:
+                del dirs[:]  # Stop os.walk from going deeper
+    return folder_contents

--- a/stopes/ui/seamlisten/react_app/src/App.tsx
+++ b/stopes/ui/seamlisten/react_app/src/App.tsx
@@ -10,8 +10,53 @@ import Navbar from "react-bootstrap/Navbar";
 import { Outlet, NavLink } from "react-router-dom";
 
 import "bootstrap/dist/css/bootstrap.min.css";
+import Notebook, { Folder } from "./components/Notebook";
 
 export function App(): JSX.Element {
+  const folders : Folder[] = [
+      {
+        name: "folder1",
+        type: "folder",
+        content: [
+          {
+            name: "file1",
+            type: "file",
+            content: "file1 content"
+          },
+          {
+            name: "file2",
+            type: "file",
+            content: "file2 content"
+          },
+          {
+            name: "file3",
+            type: "file",
+            content: "file3 content"
+          }
+        ]
+      },
+      {
+        name: "folder2",
+        type: "folder",
+        content: [
+          {
+            name: "file1",
+            type: "file",
+            content: "file1 content"
+          },
+          {
+            name: "file2",
+            type: "file",
+            content: "file2 content"
+          },
+          {
+            name: "file3",
+            type: "file",
+            content: "file3 content"
+          }
+        ]
+      }
+  ];
   return (
     <div className="App">
       <header>
@@ -34,6 +79,7 @@ export function App(): JSX.Element {
         </Navbar>
       </header>
       <Outlet />
+      <Notebook folders={folders} />
     </div>
   );
 }

--- a/stopes/ui/seamlisten/react_app/src/common/fetchers/mining_result.ts
+++ b/stopes/ui/seamlisten/react_app/src/common/fetchers/mining_result.ts
@@ -7,10 +7,11 @@
 import { config } from "../constants/config";
 import { AnnotationQuery, LineResult } from "../types/api";
 
-const url = config.host + ":" + config.port + config.annotations_route;
+const processFilesUrl = config.host + ":" + config.port + config.annotations_route;
+const processFoldersUrl = config.host + ":" + config.port + config.general_route;
 
 async function fetchFiles(data: AnnotationQuery): Promise<LineResult[]> {
-  let response = await fetch(url, {
+  let response = await fetch(processFilesUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -21,4 +22,25 @@ async function fetchFiles(data: AnnotationQuery): Promise<LineResult[]> {
   return response.json();
 }
 
-export default fetchFiles;
+async function processFolder(folderPath: string): Promise<LineResult[]> {
+  const folderQuery = {
+    gz_path: folderPath,
+    start_idx: 0, // Provide appropriate values
+    end_idx: 0,   // Provide appropriate values
+  };
+
+  const response = await fetch(processFoldersUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(folderQuery),
+  });
+
+  if (!response.ok) {
+    throw response;
+  }
+
+  return response.json();
+}
+
+export { fetchFiles, processFolder };
+

--- a/stopes/ui/seamlisten/react_app/src/components/FileExplorer.tsx
+++ b/stopes/ui/seamlisten/react_app/src/components/FileExplorer.tsx
@@ -20,7 +20,7 @@ import {
 import WaveSurferComponent from "../common/components/audio/WaveSurfer";
 import InnerScale from "../common/components/spinners/spinner";
 import { config } from "../common/constants/config";
-import fetchFiles from "../common/fetchers/mining_result";
+import {fetchFiles , processFolder} from "../common/fetchers/mining_result";
 import { LineResult } from "../common/types/api";
 import Help from "./fileviewer/FileExplorerHelp";
 import Table from "./fileviewer/Table";
@@ -68,6 +68,7 @@ export async function loader({ request }): Promise<LoaderReturn> {
     files: [],
     audioBlob: undefined,
     error: null,
+    folderContents: [], // Add folderContents field
   };
 
   try {
@@ -84,6 +85,12 @@ export async function loader({ request }): Promise<LoaderReturn> {
       toRet.files = files;
       return toRet;
     }
+    else if (isDirectoryPath(filename)){
+      const folderContents = await processFolder(filename);
+      toRet.folderContents = folderContents;
+      console.log("folderContents", folderContents);
+      return toRet;
+    }
 
     const audioResult = await text_to_audio(filename, 1);
     if (audioResult) {
@@ -96,6 +103,13 @@ export async function loader({ request }): Promise<LoaderReturn> {
     toRet.error = err;
   }
   return toRet;
+}
+
+function isDirectoryPath(path) {
+  // Implement a logic to check if the provided path is a directory
+  // You might use regular expressions or other methods to check.
+  // For example, if the path ends with "/", it's likely a directory.
+  return path.endsWith("/");
 }
 
 function Error({ error }) {

--- a/stopes/ui/seamlisten/react_app/src/components/Notebook.css
+++ b/stopes/ui/seamlisten/react_app/src/components/Notebook.css
@@ -1,0 +1,67 @@
+/* Notebook container */
+.notebook-container {
+    display: flex;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    overflow: hidden;
+  }
+  
+  /* Folder navigation panel */
+  .folder-navigation {
+    flex: 1;
+    padding: 10px;
+    background-color: #f5f5f5;
+  }
+  
+  /* Folder item */
+  .folder-item {
+    padding: 8px;
+    cursor: pointer;
+    border-radius: 3px;
+    margin-bottom: 5px;
+    transition: background-color 0.2s;
+  }
+  
+  .folder-item:hover {
+    background-color: #e0e0e0;
+  }
+  
+  .selected {
+    background-color: #2196f3;
+    color: white;
+    font-weight: bold;
+  }
+  
+  /* Notebook content panel */
+  .notebook-content {
+    flex: 3;
+    padding: 10px;
+    border-left: 1px solid #ccc;
+  }
+  
+  /* File viewer */
+  .file-viewer {
+    padding: 10px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    min-height: 200px;
+    overflow: auto;
+  }
+  
+  /* File content */
+  pre {
+    white-space: pre-wrap;
+    font-family: monospace;
+  }
+  
+  /* Default text style */
+  div {
+    font-family: Arial, sans-serif;
+  }
+  
+  /* Centered text */
+  .text-center {
+    text-align: center;
+  }
+  

--- a/stopes/ui/seamlisten/react_app/src/components/Notebook.tsx
+++ b/stopes/ui/seamlisten/react_app/src/components/Notebook.tsx
@@ -1,0 +1,109 @@
+import  { useState } from 'react';
+import './Notebook.css'; // Import your custom styling
+
+export interface Folder {
+  name: string;
+  type: 'folder';
+  content: File[];
+}
+
+interface File {
+  name: string;
+  type: 'file';
+  content: string;
+}
+
+interface Props {
+  folders: Folder[];
+}
+
+const Notebook: React.FC<Props> = ({ folders }) => {
+  const [currentFolder, setCurrentFolder] = useState<Folder | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const handleFolderClick = (folder: Folder) => {
+    setCurrentFolder(folder);
+    setSelectedFile(null);
+  };
+
+  const handleFileClick = (file: File) => {
+    setSelectedFile(file);
+  };
+
+  return (
+    <div className="notebook-container">
+      <FolderNavigation
+        folders={folders}
+        currentFolder={currentFolder}
+        onSelectFolder={handleFolderClick}
+      />
+      <div className="notebook-content">
+        {currentFolder ? (
+          <FolderView folder={currentFolder} onSelectFile={handleFileClick} />
+        ) : (
+          <div>Select a folder to view its contents</div>
+        )}
+        <FileViewer file={selectedFile} />
+      </div>
+    </div>
+  );
+};
+
+interface FolderNavigationProps {
+  folders: Folder[];
+  currentFolder: Folder | null;
+  onSelectFolder: (folder: Folder) => void;
+}
+
+const FolderNavigation: React.FC<FolderNavigationProps> = ({
+  folders,
+  currentFolder,
+  onSelectFolder,
+}) => (
+  <div className="folder-navigation">
+    {folders.map((folder) => (
+      <div
+        key={folder.name}
+        onClick={() => onSelectFolder(folder)}
+        className={`folder-item ${currentFolder === folder ? 'selected' : ''}`}
+      >
+        {folder.name}
+      </div>
+    ))}
+  </div>
+);
+
+interface FileViewerProps {
+  file: File | null;
+}
+
+const FileViewer: React.FC<FileViewerProps> = ({ file }) => (
+  <div className="file-viewer">
+    {file ? (
+      <pre>{file.content}</pre>
+    ) : (
+      <div>Select a file to view its content</div>
+    )}
+  </div>
+);
+
+interface FolderViewProps {
+  folder: Folder;
+  onSelectFile: (file: File) => void;
+}
+
+const FolderView: React.FC<FolderViewProps> = ({ folder, onSelectFile }) => (
+  <div>
+    {folder.content.map((file) => (
+      <div
+        key={file.name}
+        onClick={() => onSelectFile(file)}
+        className="file-item"
+      >
+        {file.name}
+      </div>
+    ))}
+  </div>
+);
+
+export default Notebook;


### PR DESCRIPTION
## Why ?

We need to have this feature in order to be able to explore all folders and sub folders we need to scan to look for audio files on our seamlisten tool easily (like a JupyterNotebook)

## How ?

I have build a method to gather the folder contents given the parent folder path using os.walk() method to do that effectively, and return all the folder contents in an array well constructed.
and this endpoint is called whenver the path the user enters is a path to a directory not a normal file.

## Test plan

when running the frontend and the backend successfully, paste in the field to fetch a path to a folder and when pressing fetch, if you opened the console you should see an array of folder contents shown correctly.
