### PR TITLE
Use default_factory in dataclass field of LineProcessorConfig

### DIFF
--- a/stopes/modules/preprocess/line_processor.py
+++ b/stopes/modules/preprocess/line_processor.py
@@ -69,13 +69,15 @@ class LineProcessorConfig:
     # if only hydra allowed, the right type would be tp.Union[str, tp.List[str]]
     shards: tp.Any = MISSING
     buffer_size: int = 10_000
-    requirements: Requirements = field(default_factory=lambda: Requirements(
-        nodes=1,
-        tasks_per_node=1,
-        gpus_per_node=0,
-        cpus_per_task=4,
-        timeout_min=120,
-    ))
+    requirements: Requirements = field(
+        default_factory=lambda: Requirements(
+            nodes=1,
+            tasks_per_node=1,
+            gpus_per_node=0,
+            cpus_per_task=4,
+            timeout_min=120,
+        )
+    )
     custom_name: str = ""
 
 

--- a/stopes/modules/preprocess/line_processor.py
+++ b/stopes/modules/preprocess/line_processor.py
@@ -9,7 +9,7 @@ import logging
 import typing as tp
 from abc import abstractmethod
 from contextlib import AbstractContextManager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import hydra
@@ -69,13 +69,13 @@ class LineProcessorConfig:
     # if only hydra allowed, the right type would be tp.Union[str, tp.List[str]]
     shards: tp.Any = MISSING
     buffer_size: int = 10_000
-    requirements: Requirements = Requirements(
+    requirements: Requirements = field(default_factory=lambda: Requirements(
         nodes=1,
         tasks_per_node=1,
         gpus_per_node=0,
         cpus_per_task=4,
         timeout_min=120,
-    )
+    ))
     custom_name: str = ""
 
 


### PR DESCRIPTION
## Why ?

Fix issue #70 

## How ?

use `default_factory`

## Test plan

N/A
