### PR TITLE
Fix the Github workflow tests

### DIFF
--- a/.github/workflows/lint_and_tests.yaml
+++ b/.github/workflows/lint_and_tests.yaml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 1
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.9]  # we might need a version 3.10 to pass the tests correctly
+        python-version: [3.9]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/lint_and_tests.yaml
+++ b/.github/workflows/lint_and_tests.yaml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 1
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.9]  # we might need a version 3.10 to pass the tests correctly
 
     runs-on: ${{ matrix.platform }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,3 +257,4 @@ norecursedirs = [
   "stopes/utils/aligner_utils", # it imports from a non-main branch of fairseq
   "stopes/eval/local_prosody/unity2_forced_aligner_f1", # it imports the package above
 ]
+asyncio_default_fixture_loop_scope = "session"

--- a/stopes/pipelines/tests/test_global_mining.py
+++ b/stopes/pipelines/tests/test_global_mining.py
@@ -129,6 +129,7 @@ class ToyNumbersEncoder(EncodeToNPY):
         (False, True, True, "speech"),
     ],
 )
+@pytest.mark.asyncio(scope="session")
 def test_global_mining_pipeline(
     tmp_path: Path, split_langs: bool, use_meta: bool, fp16: bool, modality: str
 ) -> None:


### PR DESCRIPTION
## Why ?

The tests seem to be falling on `main`, see e.g. https://github.com/facebookresearch/stopes/pull/71.
For the global mining test, the problem seems to be with the interaction of the test and the dependencies (maybe pytest-asyncio?), because the code itself has not changed since long ago. 

## How ?

The falling test `stopes/pipelines/tests/test_global_mining.py` was complaining about not having access to an event loop in some of its parametrized runs; apparently, the event gets closed after the first test run. 

Setting its asyncio test scope to `session` seems to fix the problem. I also remove a deprecation warning by setting explicitly `asyncio_default_fixture_loop_scope = "session"` in the project configuration.

## Test plan

Use the automatic Github workflow to run the tests. 

Before the changes (the first commit, `a dummy commit`): there is a warning on the top of the tests log `PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset`, and the global mining test is failing with `RuntimeError: There is no current event loop in thread 'MainThread'.`. 

After the changes: the warning is gone and the tests are passing.
