### PR TITLE
pump stopes to 2.2.1

### DIFF
--- a/stopes/__init__.py
+++ b/stopes/__init__.py
@@ -14,4 +14,4 @@ This toolkit contains code for several key parts of the stopes multilingual data
 
 """
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"


### PR DESCRIPTION
## Why ?

Some external repos need the latest fixes in stopes to pass the CI tests, such as[ Large Concept Model ](https://github.com/facebookresearch/large_concept_model) which requires the #72 

This PR pumps the fixes to a new minor release.
